### PR TITLE
Fix: missing hostname command issue

### DIFF
--- a/src/pg_statviz/modules/conn.py
+++ b/src/pg_statviz/modules/conn.py
@@ -1,4 +1,5 @@
 """
+
 pg_statviz - stats visualization and time series analysis
 """
 
@@ -9,7 +10,7 @@ __license__ = "PostgreSQL License"
 import argparse
 import getpass
 import logging
-import psycopg2
+import psycopg2.extensions, psycopg2.extras
 from argh.decorators import arg
 from dateutil.parser import isoparse
 from matplotlib.ticker import MaxNLocator


### PR DESCRIPTION
The python cli utlized `hostname` command to fetch the username of the system user. But in many cases, linux is not a preistalled package and hence the username is unable to be fetched. 

Utilized `uname -n` to fix incase hostname is unavailable in some systems